### PR TITLE
Publications: remove 文 glyph, add venue links, add InterpDetect

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -570,7 +570,7 @@ nav a:hover::after {
 }
 
 .publications .section-title::after {
-  content: "文";
+  display: none;
 }
 
 .publication-list {

--- a/publications.html
+++ b/publications.html
@@ -20,6 +20,30 @@
         <div class="publication-list">
           <div class="publication-item">
             <div class="publication-title">
+              InterpDetect: Interpretable Signals for Detecting Hallucinations
+              in Retrieval-Augmented Generation
+            </div>
+            <div class="publication-authors">
+              Likun Tan, Kuan-Wei Huang, Joy Shi, Kevin Wu
+            </div>
+            <div class="publication-venue">
+              NeurIPS 2025 Workshop: Generative AI in Finance
+              <a
+                href="https://neurips.cc/virtual/2025/loc/san-diego/132566"
+                target="_blank"
+                class="publication-link"
+                >NeurIPS 2025</a
+              >
+              <a
+                href="https://arxiv.org/abs/2510.21538"
+                target="_blank"
+                class="publication-link"
+                >arXiv</a
+              >
+            </div>
+          </div>
+          <div class="publication-item">
+            <div class="publication-title">
               FRED: Financial Retrieval-Enhanced Detection and Editing of
               Hallucinations in Language Models
             </div>
@@ -29,6 +53,12 @@
             <div class="publication-venue">
               ICML 2025 Workshop: Assessing World Models: Methods and Metrics
               for Evaluating Understanding
+              <a
+                href="https://openreview.net/forum?id=oPxZ01t3fH"
+                target="_blank"
+                class="publication-link"
+                >OpenReview</a
+              >
               <a
                 href="https://arxiv.org/abs/2507.20930"
                 target="_blank"
@@ -48,6 +78,12 @@
             </div>
             <div class="publication-venue">
               NeurIPS 2023 Workshop: AI4Science
+              <a
+                href="https://openreview.net/forum?id=xww53DuKJO"
+                target="_blank"
+                class="publication-link"
+                >OpenReview</a
+              >
               <a
                 href="https://arxiv.org/abs/2311.10100"
                 target="_blank"
@@ -92,6 +128,12 @@
               Monthly Notices of the Royal Astronomical Society, 510(3),
               3575-3588, 2022
               <a
+                href="https://doi.org/10.1093/mnras/stab3654"
+                target="_blank"
+                class="publication-link"
+                >MNRAS</a
+              >
+              <a
                 href="https://arxiv.org/abs/2112.06017"
                 target="_blank"
                 class="publication-link"
@@ -111,6 +153,12 @@
               Monthly Notices of the Royal Astronomical Society, 500(1),
               986-997, 2021
               <a
+                href="https://doi.org/10.1093/mnras/staa3297"
+                target="_blank"
+                class="publication-link"
+                >MNRAS</a
+              >
+              <a
                 href="https://arxiv.org/abs/2005.14014"
                 target="_blank"
                 class="publication-link"
@@ -129,6 +177,12 @@
             <div class="publication-venue">
               Monthly Notices of the Royal Astronomical Society, 496(1), 1-12,
               2020
+              <a
+                href="https://doi.org/10.1093/mnras/staa1515"
+                target="_blank"
+                class="publication-link"
+                >MNRAS</a
+              >
               <a
                 href="https://arxiv.org/abs/1906.00242"
                 target="_blank"
@@ -150,6 +204,12 @@
               Monthly Notices of the Royal Astronomical Society, 478(4),
               5063-5073, 2018
               <a
+                href="https://doi.org/10.1093/mnras/sty1329"
+                target="_blank"
+                class="publication-link"
+                >MNRAS</a
+              >
+              <a
                 href="https://arxiv.org/abs/1801.04951"
                 target="_blank"
                 class="publication-link"
@@ -167,6 +227,12 @@
             </div>
             <div class="publication-venue">
               The Astrophysical Journal, 818(1), 89, 2016
+              <a
+                href="https://doi.org/10.3847/0004-637X/818/1/89"
+                target="_blank"
+                class="publication-link"
+                >ApJ</a
+              >
               <a
                 href="https://arxiv.org/abs/1508.04621"
                 target="_blank"


### PR DESCRIPTION
## Summary
Updates to the Publications page.

- **Remove `文`** decorative character from the Publications section title.
- **Add venue links** next to arXiv for every entry:
  - 5 journal DOIs — MNRAS (×4) and ApJ, sourced from each arXiv record's related-DOI field.
  - 2 workshop OpenReview links — FRED (ICML 2025 World Models) and LenSiam (NeurIPS 2023 AI4Science).
- **Add new paper** at the top of the list: *InterpDetect: Interpretable Signals for Detecting Hallucinations in Retrieval-Augmented Generation* — NeurIPS 2025 Workshop: Generative AI in Finance (with NeurIPS + arXiv links).

## Notes
- Every publication now has a venue link plus arXiv.
- InterpDetect's website title uses the fuller arXiv title; the NeurIPS workshop version is titled "…in Financial Question Answering".

🤖 Generated with [Claude Code](https://claude.com/claude-code)